### PR TITLE
refactoring SQS handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Rin is a Redshift data Importer by SQS messaging.
 
 [Configuring Amazon S3 Event Notifications](https://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html).
 
-1. Create SQS queue.
+1. Create SQS queue. (Default Visibility Timeout setting is respected while processing messages.)
 2. Attach SQS access policy to the queue. [Example Walkthrough 1:](https://docs.aws.amazon.com/AmazonS3/latest/dev/ways-to-add-notification-config-to-bucket.html)
 3. [Enable Event Notifications](http://docs.aws.amazon.com/AmazonS3/latest/UG/SettingBucketNotifications.html) on a S3 bucket.
 4. Run `rin` process with configuration for using the SQS and S3.

--- a/rin.go
+++ b/rin.go
@@ -181,7 +181,7 @@ func handleMessages(queue *sqs.Queue) error {
 	should_retry := false
 
 	for _, msg := range res.Messages {
-		err := handleMessage(queue, msg)
+		err := handleMessage(msg)
 
 		if err != nil {
 			log.Printf("[info] [%s] Aborted message.", msg.MessageId)
@@ -209,7 +209,7 @@ func handleMessages(queue *sqs.Queue) error {
 	return nil
 }
 
-func handleMessage(queue *sqs.Queue, msg sqs.Message) error {
+func handleMessage(msg sqs.Message) error {
 	log.Printf("[info] [%s] Starting process message.", msg.MessageId)
 	log.Printf("[info] [%s] ReceiptHandle: %s", msg.MessageId, msg.ReceiptHandle)
 	if Debug {


### PR DESCRIPTION
Hi fujiwara-san,

Thank you for creating such a nice tool.
I'm also one of a person who had faced exactly the same fluentd-redshift-plugin issue as you told on your blog.

I'm considering to use Rin in our production environment, but while I was testing it I realized
- It doesn't handle Visibility Timeout so that if importing is failed or aborted, it takes a time to re-receive a message (depends on default visibility timeout setting though).
  http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/AboutVT.html
- It doesn't use batch receive messages API.

I made a few changes to implement them.
Could you please take a time to review my pull-request?

Best regards,
