### PR TITLE
Add discard option.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ _testmain.go
 
 *~
 pkg/*
+dist/*

--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ sql_option: "JSON 'auto' GZIP"       # COPY SQL option
 
 # define import target mappings
 targets:
-  - redshift:
+  - s3:
+      key_prefix: test/foo/ignore
+    discard: true  # Do not import and do not try following targets. Matches only.
+
+- redshift:
       table: foo
     s3:
       key_prefix: test/foo
@@ -71,7 +75,7 @@ targets:
       table: bar
     s3:
       key_prefix: test/bar
-    break: true       # do not try following target
+    break: true       # Do not try following targets.
 
   - redshift:
       schema: $1      # expand by key_regexp captured value.

--- a/config.go
+++ b/config.go
@@ -58,6 +58,7 @@ type Target struct {
 	S3        *S3       `yaml:"s3"`
 	SQLOption string    `yaml:"sql_option"`
 	Break     bool      `yaml:"break"`
+	Discard   bool      `yaml:"discard"`
 
 	keyMatcher func(string) (bool, *[]string)
 }

--- a/redshift.go
+++ b/redshift.go
@@ -23,6 +23,9 @@ func Import(event Event) (int, error) {
 	TARGETS:
 		for _, target := range config.Targets {
 			if ok, cap := target.MatchEventRecord(record); ok {
+				if target.Discard {
+					break TARGETS
+				}
 				err := ImportRedshift(target, record, cap)
 				if err != nil {
 					return imported, err

--- a/test/config.yml
+++ b/test/config.yml
@@ -19,6 +19,10 @@ redshift:
   password: test_pass
 
 targets:
+  - s3:
+      key_prefix: test/foo/discard
+    discard: true
+
   - redshift:
       table: foo
     s3:

--- a/test/config.yml.iam_role
+++ b/test/config.yml.iam_role
@@ -18,6 +18,10 @@ redshift:
   password: test_pass
 
 targets:
+  - s3:
+      key_prefix: test/foo/discard
+    discard: true
+
   - redshift:
       table: foo
     s3:


### PR DESCRIPTION
Do not import even if matches the target.
This is useful for ignoring some key patterns in events.