### PR TITLE
Do not raise warnings by discarded or test events.

### DIFF
--- a/event_test.go
+++ b/event_test.go
@@ -1,7 +1,7 @@
 package rin_test
 
 import (
-	"io"
+	"io/ioutil"
 	"os"
 	"testing"
 
@@ -78,7 +78,7 @@ func TestParseTestEvent(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	b, _ := io.ReadAll(f)
+	b, _ := ioutil.ReadAll(f)
 	f.Close()
 
 	event, err := rin.ParseEvent(b)

--- a/event_test.go
+++ b/event_test.go
@@ -1,6 +1,8 @@
 package rin_test
 
 import (
+	"io"
+	"os"
 	"testing"
 
 	rin "github.com/fujiwara/Rin"
@@ -50,6 +52,9 @@ func TestParseEvent(t *testing.T) {
 	if err != nil {
 		t.Error("json decode error", err)
 	}
+	if event.IsTestEvent() {
+		t.Error("must not be a test event")
+	}
 	r := event.Records[0]
 	if r.EventName != "ObjectCreated:Put" {
 		t.Error("unexpected EventName", r.EventName)
@@ -65,5 +70,25 @@ func TestParseEvent(t *testing.T) {
 	}
 	if r.S3.Object.Key != "foo/bar=baz.json" {
 		t.Error("unexpected key", r.S3.Object.Key)
+	}
+}
+
+func TestParseTestEvent(t *testing.T) {
+	f, err := os.Open("test/testevent.json")
+	if err != nil {
+		t.Error(err)
+	}
+	b, _ := io.ReadAll(f)
+	f.Close()
+
+	event, err := rin.ParseEvent(b)
+	if err != nil {
+		t.Error("json decode error", err)
+	}
+	if !event.IsTestEvent() {
+		t.Errorf("not a test event %s", string(b))
+	}
+	if event.String() != "s3:TestEvent for example-bucket" {
+		t.Errorf("unexpected string %s", event.String())
 	}
 }

--- a/redshift.go
+++ b/redshift.go
@@ -18,19 +18,20 @@ var (
 )
 
 func Import(event Event) (int, error) {
-	imported := 0
+	var processed int
 	for _, record := range event.Records {
 	TARGETS:
 		for _, target := range config.Targets {
 			if ok, cap := target.MatchEventRecord(record); ok {
 				if target.Discard {
+					processed++
 					break TARGETS
 				}
 				err := ImportRedshift(target, record, cap)
 				if err != nil {
-					return imported, err
+					return processed, err
 				} else {
-					imported++
+					processed++
 				}
 				if target.Break {
 					break TARGETS
@@ -38,7 +39,7 @@ func Import(event Event) (int, error) {
 			}
 		}
 	}
-	return imported, nil
+	return processed, nil
 }
 
 func ConnectToRedshift(target *Target) (*sql.DB, error) {

--- a/rin.go
+++ b/rin.go
@@ -191,16 +191,20 @@ func handleMessage(ctx context.Context, svc *sqs.SQS, queueUrl *string) error {
 		log.Printf("[error] [%s] Can't parse event from Body. %s", msgId, err)
 		return err
 	}
-	log.Printf("[info] [%s] Importing event: %s", msgId, event)
-	n, err := Import(event)
-	if err != nil {
-		log.Printf("[error] [%s] Import failed. %s", msgId, err)
-		return err
-	}
-	if n == 0 {
-		log.Printf("[warn] [%s] All events were not matched for any targets. Ignored.", msgId)
+	if event.IsTestEvent() {
+		log.Printf("[info] [%s] Skipping %s", msgId, event.String())
 	} else {
-		log.Printf("[info] [%s] %d import action completed.", msgId, n)
+		log.Printf("[info] [%s] Importing event: %s", msgId, event)
+		n, err := Import(event)
+		if err != nil {
+			log.Printf("[error] [%s] Import failed. %s", msgId, err)
+			return err
+		}
+		if n == 0 {
+			log.Printf("[warn] [%s] All events were not matched for any targets. Ignored.", msgId)
+		} else {
+			log.Printf("[info] [%s] %d actions completed.", msgId, n)
+		}
 	}
 	_, err = svc.DeleteMessage(&sqs.DeleteMessageInput{
 		QueueUrl:      queueUrl,

--- a/test/testevent.json
+++ b/test/testevent.json
@@ -1,0 +1,8 @@
+{
+    "Service": "Amazon S3",
+    "Event": "s3:TestEvent",
+    "Time": "2021-03-30T05:58:18.184Z",
+    "Bucket": "example-bucket",
+    "RequestId": "C0CMH2QNHV3A1SGQ",
+    "HostId": "/9JSRrT+j26Hk56OjL/qeDZM76Otmaj3oY9hnTuD/kdyN+WN6vDli3q0LPJzUMRW5y/yVmTOlzQ="
+}


### PR DESCRIPTION
- Ignore S3 test events which will be enqueued at changing event notification settings.
- Discarded events becomes to not raise warning "All events were not matched for any targets".