### PR TITLE
Reconnect on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ redshift:
   user: test_user
   password: '{{ must_env "REDSHIFT_PASSWORD" }}'
   schema: public
+  reconnect_on_error: true # disconnect Redshift on error occurred
 
 s3:
   bucket: test.bucket.test

--- a/config.go
+++ b/config.go
@@ -164,13 +164,14 @@ func (s3 S3) String() string {
 }
 
 type Redshift struct {
-	Host     string `yaml:"host"`
-	Port     int    `yaml:"port"`
-	DBName   string `yaml:"dbname"`
-	User     string `yaml:"user"`
-	Password string `yaml:"password"`
-	Schema   string `yaml:"schema"`
-	Table    string `yaml:"table"`
+	Host             string `yaml:"host"`
+	Port             int    `yaml:"port"`
+	DBName           string `yaml:"dbname"`
+	User             string `yaml:"user"`
+	Password         string `yaml:"password"`
+	Schema           string `yaml:"schema"`
+	Table            string `yaml:"table"`
+	ReconnectOnError bool   `yaml:"reconnect_on_error"`
 }
 
 func (r Redshift) DSN() string {
@@ -308,6 +309,7 @@ func (c *Config) merge() error {
 			if tr.Table == "" {
 				tr.Table = cr.Table
 			}
+			tr.ReconnectOnError = cr.ReconnectOnError
 		}
 
 		ts := t.S3

--- a/config.go
+++ b/config.go
@@ -171,7 +171,7 @@ type Redshift struct {
 	Password         string `yaml:"password"`
 	Schema           string `yaml:"schema"`
 	Table            string `yaml:"table"`
-	ReconnectOnError bool   `yaml:"reconnect_on_error"`
+	ReconnectOnError *bool  `yaml:"reconnect_on_error"`
 }
 
 func (r Redshift) DSN() string {
@@ -309,7 +309,9 @@ func (c *Config) merge() error {
 			if tr.Table == "" {
 				tr.Table = cr.Table
 			}
-			tr.ReconnectOnError = cr.ReconnectOnError
+			if tr.ReconnectOnError == nil {
+				tr.ReconnectOnError = cr.ReconnectOnError
+			}
 		}
 
 		ts := t.S3

--- a/config_test.go
+++ b/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
 	rin "github.com/fujiwara/Rin"
 )
 
@@ -119,7 +120,7 @@ func testConfig(t *testing.T, name string, expected [][]string) {
 				t.Log("break", key, "target", i)
 				break
 			}
-			if !target.Redshift.ReconnectOnError {
+			if !aws.BoolValue(target.Redshift.ReconnectOnError) {
 				t.Error("reconnect_on_error must be true")
 			}
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -119,6 +119,9 @@ func testConfig(t *testing.T, name string, expected [][]string) {
 				t.Log("break", key, "target", i)
 				break
 			}
+			if !target.Redshift.ReconnectOnError {
+				t.Error("reconnect_on_error must be true")
+			}
 		}
 		if sql != e[2] {
 			t.Errorf("unexpected SQL:\nExpected:%s\nGot:%s", e[2], sql)

--- a/redshift.go
+++ b/redshift.go
@@ -29,7 +29,7 @@ func Import(event Event) (int, error) {
 				}
 				err := ImportRedshift(target, record, cap)
 				if err != nil {
-					if config.Redshift.ReconnectOnError {
+					if aws.BoolValue(config.Redshift.ReconnectOnError) {
 						DisconnectToRedshift(target)
 					}
 					return processed, err

--- a/redshift.go
+++ b/redshift.go
@@ -29,6 +29,9 @@ func Import(event Event) (int, error) {
 				}
 				err := ImportRedshift(target, record, cap)
 				if err != nil {
+					if config.Redshift.ReconnectOnError {
+						DisconnectToRedshift(target)
+					}
 					return processed, err
 				} else {
 					processed++
@@ -40,6 +43,20 @@ func Import(event Event) (int, error) {
 		}
 	}
 	return processed, nil
+}
+
+func DisconnectToRedshift(target *Target) {
+	r := target.Redshift
+	dsn := r.DSN()
+	log.Println("Disconnect to Redshift", dsn)
+
+	DBPoolMutex.Lock()
+	defer DBPoolMutex.Unlock()
+
+	if db := DBPool[dsn]; db != nil {
+		db.Close()
+	}
+	delete(DBPool, dsn)
 }
 
 func ConnectToRedshift(target *Target) (*sql.DB, error) {

--- a/test/config.yml
+++ b/test/config.yml
@@ -17,6 +17,7 @@ redshift:
   dbname: test
   user: test_user
   password: test_pass
+  reconnect_on_error: true
 
 targets:
   - s3:

--- a/test/config.yml.iam_role
+++ b/test/config.yml.iam_role
@@ -16,6 +16,7 @@ redshift:
   dbname: test
   user: test_user
   password: test_pass
+  reconnect_on_error: true
 
 targets:
   - s3:


### PR DESCRIPTION
When Redshift is under maintenance, import actions will be failed.
These errors are no problem. But after the maintenance window, that connection to Redshift sometimes fails with "Broken Pipe" continuously.

If redshift.reconnect_on_error is set to true, Rin disconnects the connection to Redshift on error occurred at import action.

The next time, Rin will try to a new connection to Redshift.