### PR TITLE
Masking the password part of the DSN in the log

### DIFF
--- a/config.go
+++ b/config.go
@@ -181,13 +181,6 @@ func (r Redshift) DSN() string {
 	)
 }
 
-func (r Redshift) MaskedDSN() string {
-	return fmt.Sprintf("postgres://%s:*******@%s:%d/%s",
-		url.QueryEscape(r.User),
-		url.QueryEscape(r.Host), r.Port, url.QueryEscape(r.DBName),
-	)
-}
-
 func (r Redshift) DSNWith(user, password string) string {
 	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s",
 		url.QueryEscape(user), url.QueryEscape(password),

--- a/config.go
+++ b/config.go
@@ -181,6 +181,13 @@ func (r Redshift) DSN() string {
 	)
 }
 
+func (r Redshift) MaskedDSN() string {
+	return fmt.Sprintf("postgres://%s:*******@%s:%d/%s",
+		url.QueryEscape(r.User),
+		url.QueryEscape(r.Host), r.Port, url.QueryEscape(r.DBName),
+	)
+}
+
 func (r Redshift) DSNWith(user, password string) string {
 	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s",
 		url.QueryEscape(user), url.QueryEscape(password),

--- a/redshift.go
+++ b/redshift.go
@@ -48,7 +48,7 @@ func Import(event Event) (int, error) {
 func DisconnectToRedshift(target *Target) {
 	r := target.Redshift
 	dsn := r.DSN()
-	log.Println("Disconnect to Redshift", dsn)
+	log.Println("[info] Disconnect to Redshift", r.MaskedDSN())
 
 	DBPoolMutex.Lock()
 	defer DBPoolMutex.Unlock()
@@ -73,7 +73,7 @@ func ConnectToRedshift(target *Target) (*sql.DB, error) {
 			delete(DBPool, dsn)
 		}
 	}
-	log.Println("Connect to Redshift", dsn)
+	log.Println("[info] Connect to Redshift", r.MaskedDSN())
 
 	var user, password = r.User, r.Password
 	if password == "" {

--- a/redshift.go
+++ b/redshift.go
@@ -48,7 +48,7 @@ func Import(event Event) (int, error) {
 func DisconnectToRedshift(target *Target) {
 	r := target.Redshift
 	dsn := r.DSN()
-	log.Println("[info] Disconnect to Redshift", r.MaskedDSN())
+	log.Println("[info] Disconnect to Redshift", r.VisibleDSN())
 
 	DBPoolMutex.Lock()
 	defer DBPoolMutex.Unlock()
@@ -73,7 +73,7 @@ func ConnectToRedshift(target *Target) (*sql.DB, error) {
 			delete(DBPool, dsn)
 		}
 	}
-	log.Println("[info] Connect to Redshift", r.MaskedDSN())
+	log.Println("[info] Connect to Redshift", r.VisibleDSN())
 
 	var user, password = r.User, r.Password
 	if password == "" {


### PR DESCRIPTION
When we looked at the Rin log, we found that the DSN password part was output in plain text.

As a security consideration, we decided to mask the DSN password part that is output in the log.