### PR TITLE
add -max-imports and -max-exec-time option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,9 @@ install: cmd/rin/rin
 	install cmd/rin/rin ${GOPATH}/bin
 
 test-localstack:
-	docker-compose up -d
-	TEST_LOCALSTACK=on dockerize -timeout 30s -wait tcp://localhost:4576 go test -v -run Local ./...
+	docker compose up -d
+	dockerize -timeout 30s -wait tcp://localhost:4566 true
+	TEST_LOCALSTACK=on go test -v -run Local ./...
 
 test:
 	go test -v ./...

--- a/cmd/rin/main.go
+++ b/cmd/rin/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	rin "github.com/fujiwara/Rin"
 	"github.com/hashicorp/logutils"
@@ -22,6 +23,8 @@ func main() {
 		batchMode   bool
 		debug       bool
 		dryRun      bool
+		maxImports  int
+		maxExecTime time.Duration
 	)
 	flag.StringVar(&config, "config", "config.yaml", "config file path")
 	flag.StringVar(&config, "c", "config.yaml", "config file path")
@@ -32,6 +35,8 @@ func main() {
 	flag.BoolVar(&batchMode, "batch", false, "batch mode")
 	flag.BoolVar(&batchMode, "b", false, "batch mode")
 	flag.BoolVar(&dryRun, "dry-run", false, "dry run mode (load configuration only)")
+	flag.IntVar(&maxImports, "max-imports", 0, "max number of imports in batch execution")
+	flag.DurationVar(&maxExecTime, "max-exec-time", 0, "max execution time duration in batch execution (e.g 60s)")
 	flag.Parse()
 
 	if showVersion {
@@ -56,7 +61,12 @@ func main() {
 	if dryRun {
 		run = rin.DryRun
 	}
-	if err := run(config, batchMode); err != nil {
+	opt := rin.Option{
+		Batch:        batchMode,
+		MaxExecCount: maxImports,
+		MaxExecTime:  maxExecTime,
+	}
+	if err := run(config, &opt); err != nil {
 		log.Println("[error]", err)
 		os.Exit(1)
 	}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,12 +2,9 @@ version: '2.1'
 
 services:
   localstack:
-    image: localstack/localstack
+    image: localstack/localstack:0.13.3
     ports:
-      - "4572:4572" # S3
-      - "4576:4576" # SQS
-      - "4577:4577" # Redshift
-      - "${PORT_WEB_UI-8080}:${PORT_WEB_UI-8080}"
+      - "4566:4566" # localstack
     environment:
       - SERVICES=s3,sqs,redshift
       - DEBUG=${DEBUG- }

--- a/local_test.go
+++ b/local_test.go
@@ -17,9 +17,9 @@ import (
 )
 
 const (
-	SQSEndpoint      = "http://localhost:4576"
-	S3Endpoint       = "http://localhost:4572"
-	RedshiftEndpoint = "http://localhost:4577"
+	SQSEndpoint      = "http://localhost:4566"
+	S3Endpoint       = "http://localhost:4566"
+	RedshiftEndpoint = "http://localhost:4566"
 )
 
 var message = `{
@@ -53,7 +53,7 @@ var sessions = &rin.SessionStore{
 	})),
 }
 
-func TestLocalStack(t *testing.T) {
+func TestLocalStackWorker(t *testing.T) {
 	if os.Getenv("TEST_LOCALSTACK") == "" {
 		return
 	}
@@ -64,10 +64,31 @@ func TestLocalStack(t *testing.T) {
 	defer d2()
 
 	rin.Sessions = sessions
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 	defer cancel()
 
 	opt := rin.Option{}
+	if err := rin.RunWithContext(ctx, "s3://rin-test/localstack.yml", &opt); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestLocalStackBatch(t *testing.T) {
+	if os.Getenv("TEST_LOCALSTACK") == "" {
+		return
+	}
+	d1 := setupSQS(t)
+	defer d1()
+
+	d2 := setupS3(t)
+	defer d2()
+
+	rin.Sessions = sessions
+	opt := rin.Option{
+		Batch:        true,
+		MaxExecCount: 1,
+	}
+	ctx := context.TODO()
 	if err := rin.RunWithContext(ctx, "s3://rin-test/localstack.yml", &opt); err != nil {
 		t.Error(err)
 	}

--- a/local_test.go
+++ b/local_test.go
@@ -67,7 +67,8 @@ func TestLocalStack(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	if err := rin.RunWithContext(ctx, "s3://rin-test/localstack.yml", false); err != nil {
+	opt := rin.Option{}
+	if err := rin.RunWithContext(ctx, "s3://rin-test/localstack.yml", &opt); err != nil {
 		t.Error(err)
 	}
 }

--- a/option.go
+++ b/option.go
@@ -1,0 +1,52 @@
+package rin
+
+import (
+	"log"
+	"time"
+)
+
+type Option struct {
+	Batch        bool
+	MaxExecCount int
+	MaxExecTime  time.Duration
+}
+
+func (o *Option) Mode() string {
+	if o.Batch {
+		return "Batch"
+	} else {
+		return "Worker"
+	}
+}
+
+func (o *Option) NewBreakerFunc() func() bool {
+	if !o.Batch {
+		// worker mode. never break
+		return func() bool { return true }
+	}
+	var (
+		tm      *time.Timer
+		counter int
+	)
+	if o.MaxExecTime != 0 {
+		log.Printf("[debug] New timer waked after %s", o.MaxExecTime)
+		tm = time.NewTimer(o.MaxExecTime)
+	}
+	return func() bool {
+		counter++
+		if o.MaxExecCount > 0 && counter > o.MaxExecCount {
+			log.Printf("[debug] Execute %d times.", counter)
+			log.Printf("[info] Execution count reached to max exection count %d", o.MaxExecCount)
+			return true
+		}
+		if tm != nil {
+			select {
+			case <-tm.C:
+				log.Printf("[info] Timeout reached to max execution time %s", o.MaxExecTime)
+				return true
+			default:
+			}
+		}
+		return false
+	}
+}

--- a/option.go
+++ b/option.go
@@ -22,7 +22,7 @@ func (o *Option) Mode() string {
 func (o *Option) NewBreakerFunc() func() bool {
 	if !o.Batch {
 		// worker mode. never break
-		return func() bool { return true }
+		return func() bool { return false }
 	}
 	var (
 		tm      *time.Timer
@@ -35,7 +35,6 @@ func (o *Option) NewBreakerFunc() func() bool {
 	return func() bool {
 		counter++
 		if o.MaxExecCount > 0 && counter > o.MaxExecCount {
-			log.Printf("[debug] Execute %d times.", counter)
 			log.Printf("[info] Execution count reached to max exection count %d", o.MaxExecCount)
 			return true
 		}

--- a/option_test.go
+++ b/option_test.go
@@ -15,12 +15,12 @@ func TestBreakerForWorker(t *testing.T) {
 	}
 	breaker := opt.NewBreakerFunc()
 	for i := 0; i < 10000; i++ {
-		if breaker() == false {
+		if breaker() {
 			t.Error("must be true in worker mode")
 		}
 	}
 	time.Sleep(2 * time.Second)
-	if breaker() == false {
+	if breaker() {
 		t.Error("must be true in worker mode")
 	}
 }

--- a/option_test.go
+++ b/option_test.go
@@ -1,0 +1,59 @@
+package rin_test
+
+import (
+	"testing"
+	"time"
+
+	rin "github.com/fujiwara/Rin"
+)
+
+func TestBreakerForWorker(t *testing.T) {
+	opt := &rin.Option{
+		Batch:        false,
+		MaxExecTime:  time.Second,
+		MaxExecCount: 3,
+	}
+	breaker := opt.NewBreakerFunc()
+	for i := 0; i < 10000; i++ {
+		if breaker() == false {
+			t.Error("must be true in worker mode")
+		}
+	}
+	time.Sleep(2 * time.Second)
+	if breaker() == false {
+		t.Error("must be true in worker mode")
+	}
+}
+
+func TestBreakerForBatchMaxImports(t *testing.T) {
+	opt := &rin.Option{
+		Batch:        true,
+		MaxExecCount: 3,
+	}
+	breaker := opt.NewBreakerFunc()
+	for i := 0; i < 3; i++ {
+		if breaker() {
+			t.Error("must be false in batch mode")
+		}
+	}
+	if breaker() == false {
+		t.Error("must breaks after 3 times called")
+	}
+}
+
+func TestBreakerForBatchMaxExec(t *testing.T) {
+	opt := &rin.Option{
+		Batch:       true,
+		MaxExecTime: time.Second,
+	}
+	breaker := opt.NewBreakerFunc()
+	for i := 0; i < 10; i++ {
+		if breaker() {
+			t.Error("must be false in batch mode")
+		}
+	}
+	time.Sleep(2 * time.Second)
+	if breaker() == false {
+		t.Error("must breaks after 1 second")
+	}
+}

--- a/rin.go
+++ b/rin.go
@@ -40,8 +40,9 @@ func (e NoMessageError) Error() string {
 	return e.s
 }
 
-func DryRun(configFile string, batchMode bool) error {
+func DryRun(configFile string, opt *Option) error {
 	var err error
+	log.Printf("[info] Runtime option: %v", *opt)
 	log.Println("[info] Loading config:", configFile)
 	config, err = LoadConfig(configFile)
 	if err != nil {
@@ -53,12 +54,13 @@ func DryRun(configFile string, batchMode bool) error {
 	return nil
 }
 
-func Run(configFile string, batchMode bool) error {
-	return RunWithContext(context.Background(), configFile, batchMode)
+func Run(configFile string, opt *Option) error {
+	return RunWithContext(context.Background(), configFile, opt)
 }
 
-func RunWithContext(ctx context.Context, configFile string, batchMode bool) error {
+func RunWithContext(ctx context.Context, configFile string, opt *Option) error {
 	var err error
+	log.Printf("[info] Runtime option: %v", *opt)
 	log.Println("[info] Loading config:", configFile)
 	config, err = LoadConfig(configFile)
 	if err != nil {
@@ -103,7 +105,7 @@ func RunWithContext(ctx context.Context, configFile string, batchMode bool) erro
 	}()
 
 	// run worker
-	err = sqsWorker(ctx, &wg, sqsSvc, batchMode)
+	err = sqsWorker(ctx, &wg, sqsSvc, opt)
 
 	wg.Wait()
 	log.Println("[info] Shutdown.")
@@ -119,15 +121,9 @@ func waitForRetry() {
 	time.Sleep(10 * time.Second)
 }
 
-func sqsWorker(ctx context.Context, wg *sync.WaitGroup, svc *sqs.SQS, batchMode bool) error {
-	var mode string
-	if batchMode {
-		mode = "Batch"
-	} else {
-		mode = "Worker"
-	}
-	log.Printf("[info] Starting up SQS %s", mode)
-	defer log.Printf("[info] Shutdown SQS %s", mode)
+func sqsWorker(ctx context.Context, wg *sync.WaitGroup, svc *sqs.SQS, opt *Option) error {
+	log.Printf("[info] Starting up SQS %s", opt.Mode())
+	defer log.Printf("[info] Shutdown SQS %s", opt.Mode())
 	defer wg.Done()
 
 	log.Println("[info] Connect to SQS:", config.QueueName)
@@ -137,7 +133,12 @@ func sqsWorker(ctx context.Context, wg *sync.WaitGroup, svc *sqs.SQS, batchMode 
 	if err != nil {
 		return err
 	}
+	breaker := opt.NewBreakerFunc()
 	for {
+		if breaker() {
+			log.Println("[info] max execution limit reached.")
+			return nil
+		}
 		select {
 		case <-ctx.Done():
 			return nil
@@ -145,18 +146,14 @@ func sqsWorker(ctx context.Context, wg *sync.WaitGroup, svc *sqs.SQS, batchMode 
 		}
 		if err := handleMessage(ctx, svc, res.QueueUrl); err != nil {
 			if _, ok := err.(NoMessageError); ok {
-				if batchMode {
+				if opt.Batch {
 					break
-				} else {
-					continue
-				}
-				if ctx.Err() == context.Canceled {
-					return nil
-				}
-				if !batchMode {
-					waitForRetry()
 				}
 			}
+			if ctx.Err() == context.Canceled {
+				return nil
+			}
+			waitForRetry()
 		}
 	}
 	return nil

--- a/rin.go
+++ b/rin.go
@@ -163,7 +163,6 @@ func handleMessage(ctx context.Context, svc *sqs.SQS, queueUrl *string) error {
 	res, err := svc.ReceiveMessageWithContext(ctx, &sqs.ReceiveMessageInput{
 		MaxNumberOfMessages: aws.Int64(1),
 		QueueUrl:            queueUrl,
-		WaitTimeSeconds:     aws.Int64(1),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
refs #17

```console
$ rin  -help
Usage of rin
  -max-exec-time duration
        max execution time duration in batch execution (e.g 60s)
  -max-imports int
        max number of imports in batch execution
```

In batch mode, Rin breaks import action when max-exec-time or max-imports reached.