### PR TITLE
Batch lambda

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,7 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: read
-  packages: write
+permissions: write-all
 
 jobs:
   goreleaser:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export GO111MODULE := on
 
 .PHONY: test test-localstack install clean image release-image
 
-cmd/rin/rin: config.go redshift.go rin.go event.go cmd/rin/main.go
+cmd/rin/rin: *.go cmd/rin/main.go
 	cd cmd/rin && go build -ldflags "-s -w -X main.version=${GIT_VER} -X main.buildDate=${DATE}"
 
 install: cmd/rin/rin

--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Rin process new SQS messages and exit.
 $ rin -config config.yaml -batch [-debug]
 ```
 
+## Set max execution time
+
+A CLI option `-max-execution-time` is set max execution time for running SQS worker and batch process.
+
 ## SQL Drivers
 
 Rin has two ways to connect to Redshift.

--- a/cmd/rin/main.go
+++ b/cmd/rin/main.go
@@ -20,18 +20,19 @@ func main() {
 	var (
 		config      string
 		showVersion bool
-		batchMode   bool
 		debug       bool
 		dryRun      bool
 	)
+	opt := &rin.Option{}
 	flag.StringVar(&config, "config", "config.yaml", "config file path")
 	flag.StringVar(&config, "c", "config.yaml", "config file path")
 	flag.BoolVar(&debug, "debug", false, "enable debug logging")
 	flag.BoolVar(&debug, "d", false, "enable debug logging")
 	flag.BoolVar(&showVersion, "version", false, "show version")
 	flag.BoolVar(&showVersion, "v", false, "show version")
-	flag.BoolVar(&batchMode, "batch", false, "batch mode")
-	flag.BoolVar(&batchMode, "b", false, "batch mode")
+	flag.BoolVar(&opt.BatchMode, "batch", false, "batch mode")
+	flag.BoolVar(&opt.BatchMode, "b", false, "batch mode")
+	flag.DurationVar(&opt.MaxExecutionTime, "max-execution-time", 0, "max execution time")
 	flag.BoolVar(&dryRun, "dry-run", false, "dry run mode (load configuration only)")
 	flag.VisitAll(func(f *flag.Flag) {
 		if len(f.Name) <= 1 {
@@ -65,7 +66,7 @@ func main() {
 	if dryRun {
 		run = rin.DryRun
 	}
-	if err := run(config, batchMode); err != nil {
+	if err := run(config, opt); err != nil {
 		log.Println("[error]", err)
 		os.Exit(1)
 	}

--- a/cmd/rin/main.go
+++ b/cmd/rin/main.go
@@ -38,7 +38,8 @@ func main() {
 		if len(f.Name) <= 1 {
 			return
 		}
-		if s := os.Getenv(strings.ToUpper("RIN_" + f.Name)); s != "" {
+		envName := strings.ToUpper("RIN_" + strings.Replace(f.Name, "-", "_", -1))
+		if s := os.Getenv(envName); s != "" {
 			f.Value.Set(s)
 		}
 	})
@@ -61,6 +62,7 @@ func main() {
 	}
 	log.SetOutput(filter)
 	log.Println("[info] rin version:", version)
+	log.Println("[info] option:", opt.String())
 
 	run := rin.Run
 	if dryRun {

--- a/lambda.go
+++ b/lambda.go
@@ -50,8 +50,8 @@ func newLambdaSQSBatchHandler(opt *Option) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		var wg sync.WaitGroup
 		wg.Add(1)
-		defer wg.Done()
 		err := sqsWorker(ctx, &wg, opt)
+		wg.Wait()
 		if e, ok := err.(MaxExecutionTimeReachedError); ok {
 			log.Printf("[info] %s", e.Error())
 			return nil

--- a/lambda.go
+++ b/lambda.go
@@ -1,0 +1,55 @@
+package rin
+
+import (
+	"context"
+	"errors"
+	"log"
+	"sync"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+type SQSBatchResponse struct {
+	BatchItemFailures []BatchItemFailureItem `json:"batchItemFailures,omitempty"`
+}
+
+type BatchItemFailureItem struct {
+	ItemIdentifier string `json:"itemIdentifier"`
+}
+
+func runLambdaHandler(batchMode bool) error {
+	if batchMode {
+		log.Printf("[info] starting lambda handler SQS batch mode")
+		lambda.Start(lambdaSQSBatchHandler)
+	} else {
+		log.Printf("[info] starting lambda handler SQS event mode")
+		lambda.Start(lambdaSQSEventHandler)
+	}
+	return nil
+}
+
+func lambdaSQSEventHandler(ctx context.Context, event *events.SQSEvent) (*SQSBatchResponse, error) {
+	resp := &SQSBatchResponse{
+		BatchItemFailures: nil,
+	}
+	for _, record := range event.Records {
+		if record.MessageId == "" {
+			return nil, errors.New("sqs message id is empty")
+		}
+		if err := processEvent(ctx, record.MessageId, record.Body); err != nil {
+			resp.BatchItemFailures = append(resp.BatchItemFailures, BatchItemFailureItem{
+				ItemIdentifier: record.MessageId,
+			})
+		}
+	}
+	return resp, nil
+}
+
+func lambdaSQSBatchHandler(ctx context.Context) error {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	err := sqsWorker(ctx, &wg, true)
+	wg.Done()
+	return err
+}

--- a/lambda.go
+++ b/lambda.go
@@ -50,8 +50,12 @@ func newLambdaSQSBatchHandler(opt *Option) func(ctx context.Context) error {
 	return func(ctx context.Context) error {
 		var wg sync.WaitGroup
 		wg.Add(1)
+		defer wg.Done()
 		err := sqsWorker(ctx, &wg, opt)
-		wg.Done()
+		if e, ok := err.(MaxExecutionTimeReachedError); ok {
+			log.Printf("[info] %s", e.Error())
+			return nil
+		}
 		return err
 	}
 }

--- a/local_test.go
+++ b/local_test.go
@@ -94,7 +94,7 @@ func TestLocalStack(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
 
-	if err := rin.RunWithContext(ctx, "s3://rin-test/localstack.yml", false); err != nil {
+	if err := rin.RunWithContext(ctx, "s3://rin-test/localstack.yml", &rin.Option{BatchMode: false}); err != nil {
 		t.Error(err)
 	}
 }


### PR DESCRIPTION
On Lambda, SQS batch mode can work fine, not only SQS event subscriber mode.

And add `-max-execution-time` flag that can shutdown gracefully until Lambda timeout.